### PR TITLE
updated resource policy

### DIFF
--- a/src/constructs/AddDynamoStore.ts
+++ b/src/constructs/AddDynamoStore.ts
@@ -12,32 +12,28 @@ export interface IAddDynamoStore {
 
 }
 
-export class AddDynamoStore {
-    public createdTable;
-    constructor(scope: Construct, config: IAddDynamoStore) {
-        const attributes = config.sortKeyName ? [{
+export function AddDynamoStore(scope: Construct, config: IAddDynamoStore) {
+    // todo - add additional region replication
+    const attributes = config.sortKeyName ? [{
+        name: config.primaryKeyName,
+        type: config.primaryKeyType ?? "S"
+    },
+    {
+        name: config.sortKeyName,
+        type: config.sortKeyType ?? "S"
+    }] : [
+        {
             name: config.primaryKeyName,
             type: config.primaryKeyType ?? "S"
         },
-        {
-            name: config.sortKeyName,
-            type: config.sortKeyType ?? "S"
-        }] : [
-            {
-                name: config.primaryKeyName,
-                type: config.primaryKeyType ?? "S"
-            },
-        ]
-        this.createdTable = new DynamodbTable(scope, config.name, {
-            name: config.name,
-            hashKey: config.primaryKeyName,
-            rangeKey: config.sortKeyName ?? undefined,
-            billingMode: "PAY_PER_REQUEST",
-            attribute: attributes
-        })
+    ]
+    return new DynamodbTable(scope, config.name, {
+        name: config.name,
+        hashKey: config.primaryKeyName,
+        rangeKey: config.sortKeyName ?? undefined,
+        billingMode: "PAY_PER_REQUEST",
+        attribute: attributes
+    })
 
-    }
-    public getTable = () => {
-        return this.createdTable;
-    }
 }
+

--- a/src/utils/ResourcePolicies.ts
+++ b/src/utils/ResourcePolicies.ts
@@ -1,0 +1,18 @@
+export interface IDynamoResourcePolicyConfig {
+    dynamoArns: string[];
+    actions: string[];
+}
+export function GetDynamoResourcePolicy(config: IDynamoResourcePolicyConfig) {
+    return {
+        Effect: "Allow",
+        action: config.actions,
+        resource: config.dynamoArns
+    }
+
+}
+
+// export interface ILambdaResourcePolicyConfig {
+// }
+// export function GetLambdaResourcePolicy(config: ILambdaResourcePolicyConfig) {
+
+// }


### PR DESCRIPTION
This PR adds a few needed structures to manage the auth lambda and access

- Added the token table and set the access for the auth-services to all
- Set the access to the token table for the remaining lambdas to read only
- obfuscated the resource policy creation to make it easier for my use case
- set up auth integration at apigateway
- deployed and tested